### PR TITLE
Add Discord link to "Contact us" section

### DIFF
--- a/index.md
+++ b/index.md
@@ -13,6 +13,6 @@ Whether it's your first time playing chess or you've been playing for a while - 
 
 ## Contact Us
 
-If you would like to get in touch, please contact [Ollie Lenton](mailto:contact@elybeetchess.co.uk).
+If you would like to get in touch, please contact [Ollie Lenton](mailto:contact@elybeetchess.co.uk). You can also chat with us on the [Ely Beet Chess Club Discord Server](https://discord.gg/fBTdXdxuqp).
 
 <iframe src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d9736.291089220773!2d0.265469!3d52.4053573!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0xa9cc1bc22c221475!2sEly%20Beet%20Sports%20%26%20Social%20Club!5e0!3m2!1sen!2suk!4v1668725647294!5m2!1sen!2suk" width="100%" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>


### PR DESCRIPTION
Note, this invite link grants access just to "welcome-and-rules" and "newbies" channels, "member" role needs to be given to access the rest.